### PR TITLE
Support BepInEx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vs
+bin
 obj

--- a/Colorblind_Holds.csproj
+++ b/Colorblind_Holds.csproj
@@ -1,80 +1,61 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{FFA0749B-2B00-4234-BC98-E07F1AED4E70}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Colorblind_Holds</RootNamespace>
+    <TargetFramework>net472</TargetFramework>
+    <Platform>Any CPU</Platform>
+    <Version>1.1</Version>
     <AssemblyName>Colorblind_Holds</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
+    <RootNamespace>Colorblind_Holds</RootNamespace>
+    <Configurations>Debug-BepInEx;Release-BepInEx;Debug-MelonLoader;Release-MelonLoader</Configurations>
+    <Configuration Condition="'$(Configuration)' == ''">Debug-BepInEx</Configuration>
+    <IntermediateOutputPath>obj/$(Configuration)</IntermediateOutputPath>
+    <OutputPath>bin/$(Configuration.ToLower())/</OutputPath>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
+
+  <PropertyGroup Condition="$(Configuration.StartsWith('Debug-'))">
     <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
     <Optimize>false</Optimize>
-    <OutputPath>F:\SteamLibrary\steamapps\common\Peaks of Yore\Mods\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+
+  <PropertyGroup Condition="$(Configuration.StartsWith('Release-'))">
+    <DebugType>none</DebugType>
+    <DebugSymbols>false</DebugSymbols>
     <Optimize>true</Optimize>
-    <OutputPath>F:\SteamLibrary\steamapps\common\Peaks of Yore\Mods\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>F:\SteamLibrary\steamapps\common\Peaks of Yore\MelonLoader\0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>F:\SteamLibrary\steamapps\common\Peaks of Yore\Peaks of Yore_Data\Managed\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="MelonLoader">
-      <HintPath>F:\SteamLibrary\steamapps\common\Peaks of Yore\MelonLoader\MelonLoader.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine">
-      <HintPath>F:\SteamLibrary\steamapps\common\Peaks of Yore\Peaks of Yore_Data\Managed\UnityEngine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>F:\SteamLibrary\steamapps\common\Peaks of Yore\Peaks of Yore_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>F:\SteamLibrary\steamapps\common\Peaks of Yore\Peaks of Yore_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.InputLegacyModule">
-      <HintPath>F:\SteamLibrary\steamapps\common\Peaks of Yore\Peaks of Yore_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.InputModule">
-      <HintPath>F:\SteamLibrary\steamapps\common\Peaks of Yore\Peaks of Yore_Data\Managed\UnityEngine.InputModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
+
+  <PropertyGroup Condition="$(Configuration.EndsWith('-BepInEx'))">
+    <DefineConstants>BEPINEX</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(Configuration.EndsWith('-MelonLoader'))">
+    <DefineConstants>MELONLOADER</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(Configuration.EndsWith('-BepInEx'))">
+    <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all"/>
+    <PackageReference Include="BepInEx.Core" Version="5.*"/>
+    <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*"/>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Highlighter.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+
+  <ItemGroup Condition="$(Configuration.EndsWith('-MelonLoader'))">
+    <PackageReference Include="LavaGang.MelonLoader" Version="0.6.6"/>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
+  <ItemGroup>
+    <PackageReference Include="UnityEngine.Modules" Version="2019.4.36" PrivateAssets="all"/>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(OS)' == 'Unix'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all"/>
+  </ItemGroup>
+
+  <Target Name="CopyPackageAssembliesToSubFolder" AfterTargets="ResolveReferences">
+    <ItemGroup>
+      <ReferenceCopyLocalPaths
+        Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' != ''"
+        Update="$(ReferenceCopyLocalPaths)"
+        DestinationSubDirectory="libs/"/>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/Colorblind_Holds.sln
+++ b/Colorblind_Holds.sln
@@ -7,14 +7,20 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Colorblind_Holds", "Colorbl
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Debug-BepInEx|Any CPU = Debug-BepInEx|Any CPU
+		Release-BepInEx|Any CPU = Release-BepInEx|Any CPU
+		Debug-MelonLoader|Any CPU = Debug-MelonLoader|Any CPU
+		Release-MelonLoader|Any CPU = Release-MelonLoader|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{FFA0749B-2B00-4234-BC98-E07F1AED4E70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FFA0749B-2B00-4234-BC98-E07F1AED4E70}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FFA0749B-2B00-4234-BC98-E07F1AED4E70}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FFA0749B-2B00-4234-BC98-E07F1AED4E70}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FFA0749B-2B00-4234-BC98-E07F1AED4E70}.Debug-BepInEx|Any CPU.ActiveCfg = Debug-BepInEx|Any CPU
+		{FFA0749B-2B00-4234-BC98-E07F1AED4E70}.Debug-BepInEx|Any CPU.Build.0 = Debug-BepInEx|Any CPU
+		{FFA0749B-2B00-4234-BC98-E07F1AED4E70}.Release-BepInEx|Any CPU.ActiveCfg = Release-BepInEx|Any CPU
+		{FFA0749B-2B00-4234-BC98-E07F1AED4E70}.Release-BepInEx|Any CPU.Build.0 = Release-BepInEx|Any CPU
+		{FFA0749B-2B00-4234-BC98-E07F1AED4E70}.Debug-MelonLoader|Any CPU.ActiveCfg = Debug-MelonLoader|Any CPU
+		{FFA0749B-2B00-4234-BC98-E07F1AED4E70}.Debug-MelonLoader|Any CPU.Build.0 = Debug-MelonLoader|Any CPU
+		{FFA0749B-2B00-4234-BC98-E07F1AED4E70}.Release-MelonLoader|Any CPU.ActiveCfg = Release-MelonLoader|Any CPU
+		{FFA0749B-2B00-4234-BC98-E07F1AED4E70}.Release-MelonLoader|Any CPU.Build.0 = Release-MelonLoader|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="BepInEx" value="https://nuget.bepinex.dev/v3/index.json"/>
+  </packageSources>
+</configuration>

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,10 +1,15 @@
-﻿using Colorblind_Holds;
-using MelonLoader;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Runtime.InteropServices;
+
+#if MELONLOADER
+
+using Colorblind_Holds;
+using MelonLoader;
 
 [assembly: MelonInfo(typeof(Highlighter), "Colorblind Holds", "1.1", "Kalico")]
 [assembly: MelonGame("TraipseWare", "Peaks of Yore")]
+
+#endif
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information


### PR DESCRIPTION
Adds support for BepInEx.

Currently the version of the mod is specified in 2 different places, but I don't really know the best way to go about this.
For MelonLoader, it's still in Properties/AssemblyInfo.cs, for BepInEx, it's in the csproj.