### PR TITLE
Rework rendering

### DIFF
--- a/Materials.cs
+++ b/Materials.cs
@@ -1,0 +1,53 @@
+using System;
+using UnityEngine;
+
+namespace Colorblind_Holds
+{
+    public class Materials
+    {
+        private GameObject obj;
+        private Renderer renderer;
+        private Material normalMaterial;
+        private Material highlightMaterial;
+
+        public string tag { get; }
+
+        public Materials(GameObject obj, string tag, Material normalMaterial, Material highlightMaterial)
+        {
+            this.obj = obj;
+            this.tag = tag;
+            this.normalMaterial = normalMaterial;
+            this.highlightMaterial = highlightMaterial;
+            this.renderer = obj.GetComponent<Renderer>();
+        }
+
+        public void Enable(Color color)
+        {
+            if (renderer == null)
+            {
+                renderer = obj.AddComponent<MeshRenderer>();
+            }
+
+            renderer.material = highlightMaterial;
+            renderer.material.color = color;
+        }
+
+        public void Disable()
+        {
+            if (renderer == null)
+            {
+                return;
+            }
+
+            if (normalMaterial == null)
+            {
+                GameObject.DestroyImmediate(renderer);
+                renderer = null;
+            }
+            else
+            {
+                renderer.material = normalMaterial;
+            }
+        }
+    }
+}


### PR DESCRIPTION
The following can be changed without restarting the map:
- Whether to show color or use the default material
- The color to use
- Which object tags should be kept as the default material/shown with the specified color
 
Also fixes an issue where cracks would always be rendered